### PR TITLE
Add seasonal trend decomposition and channel mixing modules

### DIFF
--- a/layers/ChannelMixing.py
+++ b/layers/ChannelMixing.py
@@ -1,0 +1,37 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class GatedChannelMixing(nn.Module):
+    """Apply channel-wise attention to adaptively reweight features.
+
+    This block first summarises each channel via global average pooling
+    and then uses a small gating network to produce channel-wise gates.
+    The input is rescaled by these gates, enabling dynamic feature fusion.
+    """
+
+    def __init__(self, channels: int, reduction: int = 16, dropout: float = 0.0):
+        super().__init__()
+        hidden = max(1, channels // reduction)
+        self.fc1 = nn.Linear(channels, hidden)
+        self.fc2 = nn.Linear(hidden, channels)
+        self.dropout = nn.Dropout(dropout)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor):
+        """Forward pass.
+
+        Args:
+            x (Tensor): Input sequence [B, L, N].
+        Returns:
+            Tensor: Rescaled sequence of the same shape.
+        """
+        # Global average pooling over the temporal dimension: [B, N]
+        w = x.mean(dim=1)
+        w = self.fc1(w)
+        w = F.relu(w)
+        w = self.dropout(w)
+        w = self.fc2(w)
+        w = self.sigmoid(w).unsqueeze(1)  # [B, 1, N]
+        return x * w

--- a/layers/SeasonalTrend.py
+++ b/layers/SeasonalTrend.py
@@ -1,0 +1,37 @@
+import torch
+import torch.nn as nn
+
+
+class SeasonalTrendBlock(nn.Module):
+    """Separate a time series into seasonal and trend components using
+    a moving average filter.
+
+    Args:
+        kernel_size (int): Size of the moving average window. Must be odd.
+    """
+
+    def __init__(self, kernel_size: int = 25):
+        super().__init__()
+        if kernel_size % 2 == 0:
+            raise ValueError("kernel_size must be odd to preserve sequence length")
+        self.kernel_size = kernel_size
+        pad = (kernel_size - 1) // 2
+        # AvgPool1d performs a simple moving average over the temporal dimension
+        self.avg = nn.AvgPool1d(kernel_size, stride=1, padding=pad, count_include_pad=False)
+
+    def forward(self, x: torch.Tensor):
+        """Forward pass.
+
+        Args:
+            x (Tensor): Input sequence of shape [B, L, N].
+
+        Returns:
+            seasonal (Tensor): Seasonal component [B, L, N].
+            trend (Tensor): Trend component [B, L, N].
+        """
+        # Rearrange to [B, N, L] for pooling along the temporal dimension
+        x_t = x.transpose(1, 2)
+        trend = self.avg(x_t)
+        seasonal = x_t - trend
+        # Restore original shape [B, L, N]
+        return seasonal.transpose(1, 2), trend.transpose(1, 2)

--- a/model/SimpleTM.py
+++ b/model/SimpleTM.py
@@ -4,6 +4,8 @@ import torch.nn.functional as F
 from layers.Transformer_Encoder import Encoder, EncoderLayer
 from layers.SWTAttention_Family import GeomAttentionLayer, GeomAttention
 from layers.Embed import DataEmbedding_inverted
+from layers.SeasonalTrend import SeasonalTrendBlock
+from layers.ChannelMixing import GatedChannelMixing
 
 
 class Model(nn.Module):
@@ -16,6 +18,20 @@ class Model(nn.Module):
         self.geomattn_dropout = configs.geomattn_dropout
         self.alpha = configs.alpha
         self.kernel_size = configs.kernel_size
+
+        # Optional seasonal-trend decomposition
+        self.use_seasonal = getattr(configs, "use_seasonal", False)
+        self.seasonal_trend = SeasonalTrendBlock(
+            getattr(configs, "st_kernel_size", 25)
+        ) if self.use_seasonal else None
+
+        # Optional gated channel mixing
+        self.use_channel_mix = getattr(configs, "use_channel_mix", False)
+        self.channel_mix = GatedChannelMixing(
+            configs.dec_in,
+            reduction=getattr(configs, "mix_reduction", 16),
+            dropout=getattr(configs, "mix_dropout", 0.0),
+        ) if self.use_channel_mix else None
 
         enc_embedding = DataEmbedding_inverted(configs.seq_len, configs.d_model, 
                                                configs.embed, configs.freq, configs.dropout)
@@ -59,6 +75,15 @@ class Model(nn.Module):
             # x_enc /= stdev
             x_enc = x_enc / stdev
 
+        # Decompose into seasonal and trend components if enabled
+        if self.seasonal_trend is not None:
+            seasonal, trend = self.seasonal_trend(x_enc)
+            x_enc = seasonal
+
+        # Channel-wise mixing
+        if self.channel_mix is not None:
+            x_enc = self.channel_mix(x_enc)
+
         _, _, N = x_enc.shape
 
         enc_embedding = self.enc_embedding
@@ -82,4 +107,4 @@ class Model(nn.Module):
 
     def forward(self, x_enc, x_mark_enc, x_dec, x_mark_dec, mask=None):
         dec_out, attns = self.forecast(x_enc, None, None, None)
-        return dec_out, attns 
+        return dec_out, attns


### PR DESCRIPTION
## Summary
- add SeasonalTrendBlock for optional seasonal-trend decomposition
- add GatedChannelMixing for channel-wise attention
- integrate both modules into SimpleTM model via configurable flags

## Testing
- `python -m py_compile model/SimpleTM.py layers/SeasonalTrend.py layers/ChannelMixing.py`


------
https://chatgpt.com/codex/tasks/task_e_6890adf8475c83209eb8c23cda9fb849